### PR TITLE
Make gem-man actually work with recent RubyGems versions 

### DIFF
--- a/gem-man.gemspec
+++ b/gem-man.gemspec
@@ -3,16 +3,11 @@ Gem::Specification.new do |s|
   s.version           = "0.2.0"
   s.date              = "2010-03-06"
   s.summary           = "View a gem's man page."
-  s.homepage          = "http://github.com/defunkt/gem-man"
+  s.homepage          = "https://github.com/defunkt/gem-man"
   s.email             = "chris@ozmm.org"
   s.authors           = [ "Chris Wanstrath" ]
-  s.has_rdoc          = false
 
-  s.files             = %w( README.md Rakefile LICENSE )
-  s.files            += Dir.glob("lib/**/*")
-  s.files            += Dir.glob("bin/**/*")
-  s.files            += Dir.glob("man/**/*")
-  s.files            += Dir.glob("test/**/*")
+  s.files             = Dir.glob("{bin,lib,man}/**/*") + %w( README.md Rakefile LICENSE )
 
   s.description       = <<desc
   The `gem man` command can be used to display a man page for an

--- a/lib/rubygems/commands/man_command.rb
+++ b/lib/rubygems/commands/man_command.rb
@@ -130,7 +130,7 @@ class Gem::Commands::ManCommand < Gem::Command
       specs = specs.select { |spec| yield spec }
     end
 
-    if specs.size.zero?
+    if specs.empty?
       # If we have not tried to do a pattern match yet, fall back on it.
       if !options[:exact] && !name.is_a?(Regexp)
         pattern = /#{Regexp.escape name}/

--- a/lib/rubygems/commands/man_command.rb
+++ b/lib/rubygems/commands/man_command.rb
@@ -107,7 +107,7 @@ class Gem::Commands::ManCommand < Gem::Command
     end
 
     if manpath
-      exec "man #{File.join(gem_path(spec), manpath)}"
+      exec "man #{File.join(spec.man_dir, manpath)}"
     else
       abort "no manuals found for #{spec.name}"
     end

--- a/lib/rubygems/commands/man_command.rb
+++ b/lib/rubygems/commands/man_command.rb
@@ -62,7 +62,10 @@ class Gem::Commands::ManCommand < Gem::Command
 
     if options[:all]
       puts "These gems have man pages:", ''
-      Gem.source_index.gems.each do |name, spec|
+
+      specs = Gem::Specification.respond_to?(:each) ? Gem::Specification : Gem.source_index.gems
+      specs.each do |*name_and_spec|
+        spec = name_and_spec.pop
         puts "#{spec.name} #{spec.version}" if spec.has_manpage?
       end
     else
@@ -115,14 +118,19 @@ class Gem::Commands::ManCommand < Gem::Command
   end
 
   def get_spec(name, &block)
-    dep = Gem::Dependency.new(name, options[:version])
-    specs = Gem.source_index.search(dep)
+    # Since Gem::Dependency.new doesn't want a Regexp
+    # We'll do it ourself!
+    specs = if Gem::Specification.respond_to?(:each)
+      Gem::Specification.each.select { |spec| name === spec.name }
+    else
+      Gem.source_index.search Gem::Dependency.new(name, options[:version])
+    end
 
     if block
       specs = specs.select { |spec| yield spec }
     end
 
-    if specs.length == 0
+    if specs.size.zero?
       # If we have not tried to do a pattern match yet, fall back on it.
       if !options[:exact] && !name.is_a?(Regexp)
         pattern = /#{Regexp.escape name}/
@@ -130,7 +138,7 @@ class Gem::Commands::ManCommand < Gem::Command
       else
         nil
       end
-    elsif specs.length == 1 || options[:latest]
+    elsif specs.size == 1 || options[:latest]
       specs.last
     else
       choices = specs.map { |s| "#{s.name} #{s.version}" }

--- a/lib/rubygems/gem/specification.rb
+++ b/lib/rubygems/gem/specification.rb
@@ -1,13 +1,25 @@
 class Gem::Specification
-  # Does this specification include a manpage?
-  def has_manpage?(section = nil)
-    manpages(section).any?
+
+  ##
+  # Returns the full path to installed gem's manual directory.
+
+  def man_dir
+    @man_dir ||= File.join(respond_to?(:gem_dir) ? gem_dir : full_gem_path, 'man')
   end
 
+  ##
+  # Does this specification include a manpage?
+
+  def has_manpage?(section = nil)
+    File.directory?(man_dir) && manpages(section).any?
+  end
+
+  ##
   # Paths to the manpages included in this gem.
+
   def manpages(section = nil)
-    @files.select do |file|
-      file =~ /man\/(.+).#{section || '\d'}$/
+    Dir.entries(man_dir).select do |file|
+      file =~ /(.+).#{section || '\d'}$/
     end
   end
 end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,5 +1,5 @@
 require 'rubygems/command_manager'
-require "rubygems/version_option"
+require 'rubygems/version_option'
 require 'rubygems/gem/specification'
 
 Gem::CommandManager.instance.register_command :man


### PR DESCRIPTION
Hi Chris,

I was so sad that gem-man didn't find any manuals with current the RubyGems that I've made some changes to make it work (keeping the backward compatibility though). I've also made some few changes to update the .gemspec, like replacing http with https in the GitHub's URL! ;)

So now, I'm able to enjoy [Guard's man](https://github.com/guard/guard/blob/master/man/guard.md)!!
