### PR TITLE
follow $MANPATH directory structure

### DIFF
--- a/lib/rubygems/gem/specification.rb
+++ b/lib/rubygems/gem/specification.rb
@@ -18,8 +18,6 @@ class Gem::Specification
   # Paths to the manpages included in this gem.
 
   def manpages(section = nil)
-    Dir.entries(man_dir).select do |file|
-      file =~ /(.+).#{section || '\d'}$/
-    end
+    Dir.glob("#{man_dir}/**/*.#{section || '?'}").map {|s| s.sub(man_dir, '') }
   end
 end


### PR DESCRIPTION
gem-man doesn't follow the standard `$MANPATH` directory structure (`man/manX/Y.X` where `X` is the section number and `Y` is the manual page) but instead uses a single flattened directory (`man/Y.X`) to keep manual pages from all sections.

For example, observe how man(1) cannot find `bar.3`, whereas it can find `foo.1`:

``` sh
$ mkdir -p man/man1
$ touch man/man1/foo.1
$ touch man/bar.3
$ man -M ./man -a bar
No manual entry for bar
exit 16
$ man -M ./man -a foo     # success!
```

This prevents us from adding `man/` subdirectories in installed gems to `$MANPATH` and using plain old man(1) thereafter to look up _both_ system and gem manuals.

Thanks for your consideration.
