### PR TITLE
Search for pages instead of gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ gem-man(1) -- view a gem's man page
     gem man <SECTION> <PAGE>
     gem man --gem <GEM>
     gem man --system <PAGE>
-    gem man --latest <GEM>
+    gem man --latest <PAGE>
     gem man --exact <GEM>
     gem man --all
 
@@ -59,6 +59,9 @@ man` will ask which you'd prefer.
 
 You can specify gems or list available gems using a few options.
 
+  * `-g`, `--gem`:
+    Display pages in a specific gem instead of searching all gems.
+
   * `-s`, `--system`:
     Fall back to searching for system manuals. That is, `gem man -s
     mac` will first look for a gem named `mac` with a man page before
@@ -71,7 +74,7 @@ You can specify gems or list available gems using a few options.
   * `-v`, `--version`:
     Specify version of gem to man.
 
-  * `-e`, `--exact`:
+  * `-e`, `--exact` (only with `-g`):
     Only list exact matches.
 
   * `-a`, `--all`:
@@ -87,6 +90,7 @@ See `gem help man` to view the options at any time.
 
     gem man mustache
     gem man 1 ronn
+    gem man -g ronn
     gem man -a
 
 ## AUTHORING

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ gem-man(1) -- view a gem's man page
 
 ## SYNOPSIS
 
-    gem man <GEM>
-    gem man <SECTION> <GEM>
-    gem man --system <GEM>
+    gem man <PAGE>
+    gem man <SECTION> <PAGE>
+    gem man --gem <GEM>
+    gem man --system <PAGE>
     gem man --latest <GEM>
     gem man --exact <GEM>
     gem man --all
@@ -26,15 +27,20 @@ your shell).
 
 Metalicious.
 
-## GEM
+## PAGE
 
-`gem man` expects to be passed the name of an installed gem. If there
-are multiple man pages found for the gem, you will be asked which
-you'd like to view. If only a single man page is found it will be
-displayed.
+Name of the manual page to view. All installed gems are searched for a
+manual page named like this.
 
 Man pages are any files whose extension is a single digit [0-9],
 e.g. `ronn.1`.
+
+## GEM
+
+If `--gem` is specified, `gem man` expects to be passed the name of an
+installed gem. If there are multiple man pages found for the gem, you
+will be asked which you'd like to view. If only a single man page is
+found it will be displayed.
 
 ## SECTION
 

--- a/lib/rubygems/commands/man_command.rb
+++ b/lib/rubygems/commands/man_command.rb
@@ -196,7 +196,11 @@ class Gem::Commands::ManCommand < Gem::Command
       # narrows candidates, the final comparison excludes the
       # trailing digit ([0..-2] part).
       if manpath = spec.manpages(section).find{|path| path.split(".")[0..-2].join == name}
-        SpecPage.new(spec, manpath)
+        if options[:version].specific?
+          return [SpecPage.new(spec, manpath)] if options[:version].satisfied_by?(spec.version)
+        else
+          SpecPage.new(spec, manpath)
+        end
       end
     end.compact.sort_by{|s| s.spec.version}
   end


### PR DESCRIPTION
Hi there,

this PR makes gem-man search for page names instead of gem names. Previously, if you didn’t know which gem a manpage is contained in (e.g. you had a gem named "utilities" which contains serveral different executables and manpages) you weren’t able to view a commands manpage. Take for example the ronn-format(7) manpage. Whereas previously executing

```
$ gem man ronn-format
```

would not find anything (you had to know that manpage is contained in the `ronn` gem and hat to issue `gem man ronn`) the very same command now properly displays the ronn-format(7) manpage.

Vale,
Quintus
